### PR TITLE
Fix properties name

### DIFF
--- a/src/components/event/EventCard.tsx
+++ b/src/components/event/EventCard.tsx
@@ -11,7 +11,7 @@ import { Card, CardActions, CardHeader, CardText } from "material-ui/Card";
 export interface EventInfo {
     title: string;
     building: string;
-    hierarchy: string;
+    floor: string;
     classroom: string;
     jungle: string;
     org: string;
@@ -34,7 +34,7 @@ export class EventCard extends React.Component<EventInfo, {}> {
         }
     };
     render() {
-        const place_name = this.props.building + " " + this.props.hierarchy + " " + this.props.classroom;
+        const place_name = this.props.building + " " + this.props.floor + " " + this.props.classroom;
         return (
             <MuiThemeProvider muiTheme={getMuiTheme(lightBaseTheme)}>
                 <Card style={this.style.card}>

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -2,7 +2,7 @@
     {
         "title":"title sample",
         "building":"x棟",
-        "hierarchy":"n階",
+        "floor":"n階",
         "classroom":"xxxx",
         "jungle":"ジャンル",
         "org": "団体x",
@@ -14,7 +14,7 @@
     {
         "title":"title sample",
         "building":"x棟",
-        "hierarchy":"n階",
+        "floor":"n階",
         "classroom":"xxxx",
         "jungle":"ジャンル",
         "org": "団体x",


### PR DESCRIPTION
ヒエラルキーは建築物の階を示す単語ではない…
## やったこと
- [イベントデータ](https://github.com/sh4869/ShibaurasaiApp/blob/develop/src/data/events.json)のプロパティー名「hierarchy」を「floor」に変更
- [データを用いるコード](https://github.com/sh4869/ShibaurasaiApp/blob/develop/src/components/event/EventCard.tsx)も同様に変更
## 関連Issue
#22
