### PR TITLE
SwipeableViewsでスクロールバーが二重表示される問題

### DIFF
--- a/src/components/stage/StagePage.tsx
+++ b/src/components/stage/StagePage.tsx
@@ -29,6 +29,7 @@ export default class StagePage extends React.Component<{}, StagePageState>{
         },
         slide: {
             padding: 10,
+            overflowY: "hidden",
         },
     };
     


### PR DESCRIPTION
# 元々の問題
TabsとSwipeableViewsで作られたページで，最も縦に長いSwipeableViewsにスクロールバーが表示されるため，スクロールバーが二重に表示されていた

# やったこと
* SwipeableViewsのstyleにoverflowY: hiddenを設定し，スクロールバーの表示を抑制．

# 関連Issue
#46 